### PR TITLE
Handle more advanced queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,9 @@ authors = ["David Pedersen <david.pdrsn@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-diesel = { version = "^1.4", features = ["postgres"] }
+diesel = { version = "^1.4", features = ["postgres", "chrono"] }
 
 [dev-dependencies]
 diesel-factories = "0.1.2"
+chrono = "0.4.7"
+trybuild = "1.0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ where
 
     // This `Copy` is necessary because `.eq` moves `self`
     // Diesel columns always implement `Copy` to should be save
-    CursorColumn: Expression + ExpressionMethods + Copy,
+    CursorColumn: ExpressionMethods + Copy,
     // This `Clone` is necessary because `.as_expression` moves `self`
     // There might be a way to get around it, but I don't know how yet
     Cursor: AsExpression<CursorColumn::SqlType> + Clone,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ impl<Query: query_builder::Query, Order, Cursor, CursorColumn> query_builder::Qu
     type SqlType = Query::SqlType;
 }
 
-impl<Query, Order, Cursor, CursorColumn> RunQueryDsl<PgConnection>
+impl<Query, Order, Cursor, CursorColumn, C> RunQueryDsl<C>
     for KeysetPaginated<Query, Order, Cursor, CursorColumn>
 {
 }

--- a/tests/compile_fail/invalid_cursor_columns.rs
+++ b/tests/compile_fail/invalid_cursor_columns.rs
@@ -1,0 +1,51 @@
+#![allow(unused_imports)]
+
+#[macro_use]
+extern crate diesel;
+
+use chrono::prelude::*;
+use diesel_keyset_pagination::*;
+use diesel::prelude::*;
+use schema::*;
+
+mod schema {
+    table! {
+        users (id) {
+            firstname -> Text,
+            id -> Integer,
+            lastname -> Text,
+            slug -> Text,
+        }
+    }
+
+    table! {
+        follows (id) {
+            followee_id -> Integer,
+            followee_type -> Nullable<Text>,
+            follower_id -> Integer,
+            id -> Integer,
+            source -> Nullable<Text>,
+            unfollowed_at -> Nullable<Timestamptz>,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Debug, Clone, Queryable)]
+pub struct User {
+    pub firstname: String,
+    pub id: i32,
+    pub lastname: String,
+    pub slug: String,
+}
+
+fn main() {
+    let url = "postgres://localhost/tonsser-api_test";
+    let db = PgConnection::establish(url).unwrap();
+
+    users::table
+        .select(users::all_columns)
+        .keyset_paginate_order_by(users::id)
+        .page_size(2)
+        .cursor(follows::id, None::<i32>)
+        .load::<User>(&db).unwrap();
+}

--- a/tests/compile_fail/invalid_cursor_columns.stderr
+++ b/tests/compile_fail/invalid_cursor_columns.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `diesel::query_builder::SelectStatement<schema::users::table, diesel::query_builder::select_clause::SelectClause<(schema::users::columns::firstname, schema::users::columns::id, schema::users::columns::lastname, schema::users::columns::slug)>>: diesel::query_dsl::select_dsl::SelectDsl<schema::follows::columns::id>` is not satisfied
+  --> $DIR/invalid_cursor_columns.rs:50:10
+   |
+50 |         .load::<User>(&db).unwrap();
+   |          ^^^^ the trait `diesel::query_dsl::select_dsl::SelectDsl<schema::follows::columns::id>` is not implemented for `diesel::query_builder::SelectStatement<schema::users::table, diesel::query_builder::select_clause::SelectClause<(schema::users::columns::firstname, schema::users::columns::id, schema::users::columns::lastname, schema::users::columns::slug)>>`
+   |
+   = help: the following implementations were found:
+             <diesel::query_builder::SelectStatement<F, S, D, W, O, L, Of, G, LC> as diesel::query_dsl::select_dsl::SelectDsl<Selection>>
+   = note: required because of the requirements on the impl of `diesel::query_builder::QueryFragment<diesel::pg::Pg>` for `diesel_keyset_pagination::KeysetPaginated<diesel::query_builder::SelectStatement<schema::users::table, diesel::query_builder::select_clause::SelectClause<(schema::users::columns::firstname, schema::users::columns::id, schema::users::columns::lastname, schema::users::columns::slug)>>, schema::users::columns::id, i32, schema::follows::columns::id>`
+   = note: required because of the requirements on the impl of `diesel::query_dsl::LoadQuery<_, User>` for `diesel_keyset_pagination::KeysetPaginated<diesel::query_builder::SelectStatement<schema::users::table, diesel::query_builder::select_clause::SelectClause<(schema::users::columns::firstname, schema::users::columns::id, schema::users::columns::lastname, schema::users::columns::slug)>>, schema::users::columns::id, i32, schema::follows::columns::id>`
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/compile_fail/invalid_order_by_columns.rs
+++ b/tests/compile_fail/invalid_order_by_columns.rs
@@ -1,0 +1,52 @@
+#![allow(unused_imports)]
+
+#[macro_use]
+extern crate diesel;
+
+use chrono::prelude::*;
+use diesel_keyset_pagination::*;
+use diesel::prelude::*;
+use schema::*;
+
+mod schema {
+    table! {
+        users (id) {
+            firstname -> Text,
+            id -> Integer,
+            lastname -> Text,
+            slug -> Text,
+        }
+    }
+
+    table! {
+        follows (id) {
+            followee_id -> Integer,
+            followee_type -> Nullable<Text>,
+            follower_id -> Integer,
+            id -> Integer,
+            source -> Nullable<Text>,
+            unfollowed_at -> Nullable<Timestamptz>,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Debug, Clone, Queryable)]
+pub struct User {
+    pub firstname: String,
+    pub id: i32,
+    pub lastname: String,
+    pub slug: String,
+}
+
+fn main() {
+    let url = "postgres://localhost/tonsser-api_test";
+    let db = PgConnection::establish(url).unwrap();
+
+    users::table
+        .select(users::all_columns)
+        .keyset_paginate_order_by(follows::id)
+        .page_size(2)
+        .cursor(users::id, None::<i32>)
+        .load::<User>(&db)
+        .unwrap();
+}

--- a/tests/compile_fail/invalid_order_by_columns.stderr
+++ b/tests/compile_fail/invalid_order_by_columns.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `diesel::query_builder::SelectStatement<schema::users::table, diesel::query_builder::select_clause::SelectClause<(schema::users::columns::firstname, schema::users::columns::id, schema::users::columns::lastname, schema::users::columns::slug)>>: diesel::query_dsl::select_dsl::SelectDsl<schema::follows::columns::id>` is not satisfied
+  --> $DIR/invalid_order_by_columns.rs:50:10
+   |
+50 |         .load::<User>(&db)
+   |          ^^^^ the trait `diesel::query_dsl::select_dsl::SelectDsl<schema::follows::columns::id>` is not implemented for `diesel::query_builder::SelectStatement<schema::users::table, diesel::query_builder::select_clause::SelectClause<(schema::users::columns::firstname, schema::users::columns::id, schema::users::columns::lastname, schema::users::columns::slug)>>`
+   |
+   = help: the following implementations were found:
+             <diesel::query_builder::SelectStatement<F, S, D, W, O, L, Of, G, LC> as diesel::query_dsl::select_dsl::SelectDsl<Selection>>
+   = note: required because of the requirements on the impl of `diesel::query_builder::QueryFragment<diesel::pg::Pg>` for `diesel_keyset_pagination::KeysetPaginated<diesel::query_builder::SelectStatement<schema::users::table, diesel::query_builder::select_clause::SelectClause<(schema::users::columns::firstname, schema::users::columns::id, schema::users::columns::lastname, schema::users::columns::slug)>>, schema::follows::columns::id, i32, schema::users::columns::id>`
+   = note: required because of the requirements on the impl of `diesel::query_dsl::LoadQuery<_, User>` for `diesel_keyset_pagination::KeysetPaginated<diesel::query_builder::SelectStatement<schema::users::table, diesel::query_builder::select_clause::SelectClause<(schema::users::columns::firstname, schema::users::columns::id, schema::users::columns::lastname, schema::users::columns::slug)>>, schema::follows::columns::id, i32, schema::users::columns::id>`
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #1 

Getting the "from clause" from a join query was tricky. I guess that makes sense since a join query technically has several table sources. However if you change the API a bit so you pass in the column the cursor belongs to, then we're able to get the query source from that column.

I have no idea if this is enough type safety, but at least it works 😊 

## TODO

- [x] Verify that the order clause doesn't contain columns that aren't being selected.